### PR TITLE
Fix code scanning alert no. 4: Flask app is run in debug mode

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,6 @@
 from app import app
+import os
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/prathmesh796/Exceller/security/code-scanning/4](https://github.com/prathmesh796/Exceller/security/code-scanning/4)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

1. Modify the `app.run(debug=True)` line to check an environment variable that determines whether to run in debug mode.
2. Import the `os` module to access environment variables.
3. Set a default value for the debug mode to `False` to ensure it is disabled by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
